### PR TITLE
Reverts Single-Target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,9 +16,16 @@ let package = Package(
         .library(
             name: "Harness",
             targets: [
+                "Harness"
+            ]
+        ),
+        .library(
+            name: "HarnessXCTest",
+            targets: [
                 "Harness",
                 "HarnessXCTest"
-            ]),
+            ]
+        ),
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
@@ -29,12 +36,21 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "Harness",
-            dependencies: []),
+            dependencies: [
+            ]
+        ),
         .target(
             name: "HarnessXCTest",
-            dependencies: ["Harness"]),
+            dependencies: [
+                "Harness"
+            ]
+        ),
         .testTarget(
             name: "HarnessTests",
-            dependencies: ["Harness", "HarnessXCTest"]),
+            dependencies: [
+                "Harness",
+                "HarnessXCTest"
+            ]
+        ),
     ]
 )


### PR DESCRIPTION
Having a single **Harness** target was causing integration problems into projects. The usage of XCTest can cause build failures when the target does not import the framework. Importing the framework into an app target can cause issues with test targets.

Now, the intended usage is to either import **Harness** or **HarnessXCTest**.